### PR TITLE
Chrome-specific CSS fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The logo is a combination of the DeArrow logo and the magnifying glass emoji fro
 ## Running an instance
 1. Build the image
 ```sh
-docker buid -t dearrow-browser .
+docker build -t dearrow-browser .
 ```
 2. Create a config.toml file. Static content (frontend) is available at /static in the container.
 3. Run the container

--- a/dearrow-browser-frontend/index.scss
+++ b/dearrow-browser-frontend/index.scss
@@ -5,6 +5,10 @@ $white: #eee;
   background-color: #222;
 }
 
+:root {
+  color-scheme: dark;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -25,7 +29,11 @@ body {
   display: flex;
   flex-direction: row;
   gap: 2rem;
-
+  
+  > img {
+    height: 100%;
+  }
+  
   > div {
     display: flex;
     align-items: center;


### PR DESCRIPTION
1. make scrollbars use dark theming
2. fix the header image width bug
3. fix a typo in the readme ("buid" -> "build")

I also tested in Firefox, didn't change anything afaict

Note: I only tested the CSS using Stylus b/c I was too lazy to setup a docker container, but it should ™️ work. 